### PR TITLE
Fix Response::content_length to check the header

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -91,6 +91,15 @@ impl Response {
     ///   the actual decoded length).
     pub fn content_length(&self) -> Option<u64> {
         use hyper::body::HttpBody;
+        use crate::header::CONTENT_LENGTH;
+
+        if let Some(value) = self.headers.get(CONTENT_LENGTH) {
+            if let Ok(value_str) = value.to_str() {
+                if let Ok(length) = value_str.parse::<u64>() {
+                    return Some(length)
+                }
+            }
+        }
 
         HttpBody::size_hint(&self.body).exact()
     }


### PR DESCRIPTION
Response::content_length didn't check the header for the content length of the response, even though this is promised by the documentation. It now does check that field.

Closes seanmonstar#1136